### PR TITLE
Port WebSphereMQ workaround to ruby 1.9 syntax

### DIFF
--- a/lib/jms/mq_workaround.rb
+++ b/lib/jms/mq_workaround.rb
@@ -4,7 +4,7 @@ begin
   
   class com.ibm.mq.jms::MQQueueSession
     
-    if self.instance_methods.include? "consume"
+    if self.method_defined? :consume
       def consume(params, &proc)
         Java::JavaxJms::Session.instance_method(:consume).bind(self).call(params, &proc)
       end
@@ -15,13 +15,13 @@ begin
 
   class com.ibm.mq.jms::MQSession
 
-    if self.instance_methods.include? "consume"
+    if self.method_defined? :consume
       def consume(params, &proc)
         Java::JavaxJms::Session.instance_method(:consume).bind(self).call(params, &proc)
       end
     end
     
-    if self.instance_methods.include? "create_destination"
+    if self.method_defined? :create_destination
       def create_destination(params)
         Java::JavaxJms::Session.instance_method(:create_destination).bind(self).call(params)
       end
@@ -32,7 +32,7 @@ begin
   
   class com.ibm.mq.jms::MQQueueBrowser
 
-    if self.instance_methods.include? "each"
+    if self.method_defined? :each
       def each(params, &proc)
         Java::ComIbmMsgClientJms::JmsQueueBrowser.instance_method(:each).bind(self).call(params, &proc)
       end
@@ -42,13 +42,13 @@ begin
 
   class com.ibm.mq.jms::MQQueueReceiver
     
-    if self.instance_methods.include? "each"
+    if self.method_defined? :each
       def each(params, &proc)
         Java::JavaxJms::MessageConsumer.instance_method(:each).bind(self).call(params, &proc)
       end
     end
     
-    if self.instance_methods.include? "get"
+    if self.method_defined? :get
       def get(params={})
         Java::JavaxJms::MessageConsumer.instance_method(:get).bind(self).call(params)
       end
@@ -59,7 +59,7 @@ begin
   
   class com.ibm.mq.jms::MQQueue
     
-    if self.instance_methods.include? "delete"
+    if self.method_defined? :delete
     undef_method :delete
     end
     

--- a/test/session_pool_test.rb
+++ b/test/session_pool_test.rb
@@ -6,6 +6,7 @@ require 'test/unit'
 require 'shoulda'
 require 'jms'
 require 'yaml'
+require 'timeout'
 
 class JMSTest < Test::Unit::TestCase
   context 'JMS Session' do


### PR DESCRIPTION
In 1.9 syntax `instance_methods` return symbols, not strings. Replaced `instance_methods.include?` with `method_defined?`. Should be backward compatible with 1.8.
